### PR TITLE
프로젝트 기본구조 구현 #3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'com.vladmihalcea:hibernate-types-55:2.20.0'					// json in mysql
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/dsadara/aptApp/agent/entity/Agent.java
+++ b/src/main/java/com/dsadara/aptApp/agent/entity/Agent.java
@@ -1,0 +1,29 @@
+package com.dsadara.aptApp.agent.entity;
+
+import com.dsadara.aptApp.common.entity.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Agent extends BaseEntity {
+    private String email;               // 이메일
+    private String password;            // 비밀번호
+    private String name;                // 이름
+    private Double rating_avg;          // 평점 평균
+    private String profile_picture_url; // 프로필사진
+    private String phone;               // 연락처
+    private String as4;                 // 담당 동리
+    private String email_auth_key;      // 이메일 인증키
+    private LocalDateTime email_auth_key_due_date; // 이메일 인증키 유효기간
+    private Boolean email_auth_yn;      // 이메일 인증여부
+    private String accessToken;         // 액세스 토큰
+}

--- a/src/main/java/com/dsadara/aptApp/agent/entity/CommentAgent.java
+++ b/src/main/java/com/dsadara/aptApp/agent/entity/CommentAgent.java
@@ -1,0 +1,31 @@
+package com.dsadara.aptApp.agent.entity;
+
+import com.dsadara.aptApp.common.entity.BaseEntity;
+import com.dsadara.aptApp.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class CommentAgent extends BaseEntity {
+    @Lob
+    private String content;     // 후기 내용
+    private Integer rating;     // 평점
+
+    @ManyToOne
+    @JoinColumn(name="ID_MEMBER")
+    private Member member;      // 회원번호
+    @ManyToOne
+    @JoinColumn(name="ID_AGENT")
+    private Agent agent;        // 중개사번호
+}

--- a/src/main/java/com/dsadara/aptApp/agent/entity/Consult.java
+++ b/src/main/java/com/dsadara/aptApp/agent/entity/Consult.java
@@ -1,0 +1,33 @@
+package com.dsadara.aptApp.agent.entity;
+
+import com.dsadara.aptApp.common.entity.BaseEntity;
+import com.dsadara.aptApp.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Type;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Consult extends BaseEntity {
+    @Type(type = "json")
+    @Column(columnDefinition = "json")
+    private String chat_log;    // 채팅기록
+    private Boolean finish_yn;  // 종료여부
+
+    @ManyToOne
+    @JoinColumn(name="ID_MEMBER")
+    private Member member;      // 회원번호
+    @ManyToOne
+    @JoinColumn(name="ID_AGENT")
+    private Agent agent;        // 중개사번호
+}

--- a/src/main/java/com/dsadara/aptApp/agent/repository/AgentRepository.java
+++ b/src/main/java/com/dsadara/aptApp/agent/repository/AgentRepository.java
@@ -1,0 +1,9 @@
+package com.dsadara.aptApp.agent.repository;
+
+import com.dsadara.aptApp.agent.entity.Agent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AgentRepository extends JpaRepository<Agent, Long> {
+}

--- a/src/main/java/com/dsadara/aptApp/agent/repository/CommentAgentRepository.java
+++ b/src/main/java/com/dsadara/aptApp/agent/repository/CommentAgentRepository.java
@@ -1,0 +1,9 @@
+package com.dsadara.aptApp.agent.repository;
+
+import com.dsadara.aptApp.agent.entity.CommentAgent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentAgentRepository extends JpaRepository<CommentAgent, Long> {
+}

--- a/src/main/java/com/dsadara/aptApp/agent/repository/ConsultRepository.java
+++ b/src/main/java/com/dsadara/aptApp/agent/repository/ConsultRepository.java
@@ -1,0 +1,9 @@
+package com.dsadara.aptApp.agent.repository;
+
+import com.dsadara.aptApp.agent.entity.Consult;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ConsultRepository extends JpaRepository<Consult, Long> {
+}

--- a/src/main/java/com/dsadara/aptApp/apartment/entity/Apartment.java
+++ b/src/main/java/com/dsadara/aptApp/apartment/entity/Apartment.java
@@ -1,0 +1,40 @@
+package com.dsadara.aptApp.apartment.entity;
+
+import com.dsadara.aptApp.common.entity.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Type;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Apartment extends BaseEntity {
+    private String aptCode;         // 단지코드
+    private String amountRecent;    // 최근 거래금액
+    private Integer viewWeek;     // 주간 조회수
+    private Integer viewTotal;      // 전체 조회수
+    private String name;            // 단지명
+    private String as1;             // 시, 도
+    private String as2;             // 시, 군, 구
+    private String as3;             // 읍, 면
+    private String as4;             // 동, 리
+    private String drmAddress;          // 도로명주소
+    private LocalDateTime apprvDate;    // 사용승인일
+    private Integer dongNo;             // 동수
+    private Integer houseNo;            // 세대수
+    private Integer parkingSpaceNo;     // 총 주차대수
+    private String bjdCode;             // 법정동코드
+
+    @Type(type="json")
+    @Column(columnDefinition = "json")
+    private List<String> feature;   // 특징
+}

--- a/src/main/java/com/dsadara/aptApp/apartment/entity/CommentApt.java
+++ b/src/main/java/com/dsadara/aptApp/apartment/entity/CommentApt.java
@@ -1,0 +1,30 @@
+package com.dsadara.aptApp.apartment.entity;
+
+import com.dsadara.aptApp.common.entity.BaseEntity;
+import com.dsadara.aptApp.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class CommentApt extends BaseEntity {
+    @Lob
+    private String content;         // 덧글내용
+
+    @ManyToOne
+    @JoinColumn(name="ID_APT")
+    private Apartment apartment;    // 아파트 ID
+    @ManyToOne
+    @JoinColumn(name="ID_MEMBER")
+    private Member member;          // 회원번호
+}

--- a/src/main/java/com/dsadara/aptApp/apartment/entity/FavoriteApt.java
+++ b/src/main/java/com/dsadara/aptApp/apartment/entity/FavoriteApt.java
@@ -1,0 +1,26 @@
+package com.dsadara.aptApp.apartment.entity;
+
+import com.dsadara.aptApp.common.entity.BaseEntity;
+import com.dsadara.aptApp.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class FavoriteApt extends BaseEntity {
+    @ManyToOne
+    @JoinColumn(name="ID_APT")
+    private Apartment apartment;    // 아파트 ID
+    @ManyToOne
+    @JoinColumn(name="ID_MEMBER")
+    private Member member;          // 회원번호
+}

--- a/src/main/java/com/dsadara/aptApp/apartment/repository/ApartmentRepository.java
+++ b/src/main/java/com/dsadara/aptApp/apartment/repository/ApartmentRepository.java
@@ -1,0 +1,9 @@
+package com.dsadara.aptApp.apartment.repository;
+
+import com.dsadara.aptApp.apartment.entity.Apartment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApartmentRepository extends JpaRepository<Apartment, Long> {
+}

--- a/src/main/java/com/dsadara/aptApp/apartment/repository/CommentAptRepository.java
+++ b/src/main/java/com/dsadara/aptApp/apartment/repository/CommentAptRepository.java
@@ -1,0 +1,9 @@
+package com.dsadara.aptApp.apartment.repository;
+
+import com.dsadara.aptApp.apartment.entity.CommentApt;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentAptRepository extends JpaRepository<CommentApt, Long> {
+}

--- a/src/main/java/com/dsadara/aptApp/apartment/repository/FavoriteAptRepository.java
+++ b/src/main/java/com/dsadara/aptApp/apartment/repository/FavoriteAptRepository.java
@@ -1,0 +1,9 @@
+package com.dsadara.aptApp.apartment.repository;
+
+import com.dsadara.aptApp.apartment.entity.FavoriteApt;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FavoriteAptRepository extends JpaRepository<FavoriteApt, Long> {
+}

--- a/src/main/java/com/dsadara/aptApp/common/config/JpaAuditingConfiguration.java
+++ b/src/main/java/com/dsadara/aptApp/common/config/JpaAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package com.dsadara.aptApp.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+}

--- a/src/main/java/com/dsadara/aptApp/common/entity/BaseEntity.java
+++ b/src/main/java/com/dsadara/aptApp/common/entity/BaseEntity.java
@@ -1,0 +1,32 @@
+package com.dsadara.aptApp.common.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/dsadara/aptApp/main/MainController.java
+++ b/src/main/java/com/dsadara/aptApp/main/MainController.java
@@ -1,4 +1,4 @@
-package com.dsadara.aptApp;
+package com.dsadara.aptApp.main;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/dsadara/aptApp/member/entity/Member.java
+++ b/src/main/java/com/dsadara/aptApp/member/entity/Member.java
@@ -1,0 +1,25 @@
+package com.dsadara.aptApp.member.entity;
+
+import com.dsadara.aptApp.common.entity.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Member extends BaseEntity {
+    private String email;                   // 이메일
+    private String password;                // 비밀번호
+    private String name;                    // 이름
+    private String emailAuthKey;            // 이메일인증키
+    private LocalDateTime emailAuthDueDate; // 이메일인증키 유효기간
+    private Boolean emailAuthYn;            // 이메일인증여부
+    private String accessToken;             // 액세스 토큰
+}

--- a/src/main/java/com/dsadara/aptApp/member/repository/MemberRepository.java
+++ b/src/main/java/com/dsadara/aptApp/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.dsadara.aptApp.member.repository;
+
+import com.dsadara.aptApp.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/dsadara/aptApp/transaction/entity/RequestTransaction.java
+++ b/src/main/java/com/dsadara/aptApp/transaction/entity/RequestTransaction.java
@@ -1,0 +1,33 @@
+package com.dsadara.aptApp.transaction.entity;
+
+import com.dsadara.aptApp.agent.entity.Agent;
+import com.dsadara.aptApp.common.entity.BaseEntity;
+import com.dsadara.aptApp.member.entity.Member;
+import com.dsadara.aptApp.transaction.type.RequestStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class RequestTransaction extends BaseEntity {
+    @Enumerated(EnumType.STRING)
+    private RequestStatus requestStatus;    // 신청상태
+
+    @ManyToOne
+    @JoinColumn(name="ID_TRANSACTION")
+    private Transaction transaction;        // 매물 ID
+    @ManyToOne
+    @JoinColumn(name="ID_MEMBER")
+    private Member member;                  // 회원번호
+    @ManyToOne
+    @JoinColumn(name="ID_AGENT")
+    private Agent agent;                    // 중개사번호
+
+}

--- a/src/main/java/com/dsadara/aptApp/transaction/entity/Transaction.java
+++ b/src/main/java/com/dsadara/aptApp/transaction/entity/Transaction.java
@@ -1,0 +1,42 @@
+package com.dsadara.aptApp.transaction.entity;
+
+import com.dsadara.aptApp.agent.entity.Agent;
+import com.dsadara.aptApp.apartment.entity.Apartment;
+import com.dsadara.aptApp.common.entity.BaseEntity;
+import com.dsadara.aptApp.member.entity.Member;
+import com.dsadara.aptApp.transaction.type.TransactionStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Transaction extends BaseEntity {
+    private Long amount;                // 거래금액
+    private String aptName;             // 단지명
+    private String pictures_url;        // 내부사진주소
+    private Double areaExclusive;       // 전용면적
+    private Integer floor;              // 층
+
+    @Lob
+    private String description;         // 추가설명
+    @Enumerated(EnumType.STRING)
+    private TransactionStatus transactionStatus;    // 거래진행상황
+    private Long buyerId;                           // 거래신청 회원번호
+
+    @ManyToOne
+    @JoinColumn(name="ID_APT")
+    private Apartment apartment;                    // 아파트 ID
+    @ManyToOne
+    @JoinColumn(name="ID_AGENT")
+    private Agent agent;                            // 중개사번호
+    @ManyToOne
+    @JoinColumn(name="ID_MEMBER")
+    private Member member;                          // 회원번호
+}

--- a/src/main/java/com/dsadara/aptApp/transaction/entity/TransactionReal.java
+++ b/src/main/java/com/dsadara/aptApp/transaction/entity/TransactionReal.java
@@ -1,0 +1,35 @@
+package com.dsadara.aptApp.transaction.entity;
+
+import com.dsadara.aptApp.apartment.entity.Apartment;
+import com.dsadara.aptApp.common.entity.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class TransactionReal extends BaseEntity {
+    private Long amount;            // 거래금액
+    private String aptName;         // 단지명
+    private Double areaExclusive;   // 전용면적
+    private Integer floor;          // 층
+    private LocalDateTime contractDate;     // 계약일
+    private String bjdCode;                 // 법정동코드
+
+    @ManyToOne
+    @JoinColumn(name="ID_APT")
+    private Apartment apartment;            // 아파트ID
+    @OneToOne
+    @JoinColumn(name="ID_TRANSACTION")
+    private Transaction transaction;        // 매물ID
+}

--- a/src/main/java/com/dsadara/aptApp/transaction/repository/RequestTransactionRepository.java
+++ b/src/main/java/com/dsadara/aptApp/transaction/repository/RequestTransactionRepository.java
@@ -1,0 +1,9 @@
+package com.dsadara.aptApp.transaction.repository;
+
+import com.dsadara.aptApp.transaction.entity.RequestTransaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RequestTransactionRepository extends JpaRepository<RequestTransaction, Long> {
+}

--- a/src/main/java/com/dsadara/aptApp/transaction/repository/TransactionRealRepository.java
+++ b/src/main/java/com/dsadara/aptApp/transaction/repository/TransactionRealRepository.java
@@ -1,0 +1,9 @@
+package com.dsadara.aptApp.transaction.repository;
+
+import com.dsadara.aptApp.transaction.entity.TransactionReal;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TransactionRealRepository extends JpaRepository<TransactionReal, Long> {
+}

--- a/src/main/java/com/dsadara/aptApp/transaction/repository/TransactionRepository.java
+++ b/src/main/java/com/dsadara/aptApp/transaction/repository/TransactionRepository.java
@@ -1,0 +1,9 @@
+package com.dsadara.aptApp.transaction.repository;
+
+import com.dsadara.aptApp.transaction.entity.Transaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TransactionRepository extends JpaRepository<Transaction, Long> {
+}

--- a/src/main/java/com/dsadara/aptApp/transaction/type/RequestStatus.java
+++ b/src/main/java/com/dsadara/aptApp/transaction/type/RequestStatus.java
@@ -1,0 +1,7 @@
+package com.dsadara.aptApp.transaction.type;
+
+public enum RequestStatus {
+    WAIT_FOR_APPROVE,
+    APPROVED,
+    DECLINED,
+}

--- a/src/main/java/com/dsadara/aptApp/transaction/type/TransactionStatus.java
+++ b/src/main/java/com/dsadara/aptApp/transaction/type/TransactionStatus.java
@@ -1,0 +1,8 @@
+package com.dsadara.aptApp.transaction.type;
+
+public enum TransactionStatus {
+    WAIT_FOR_REQUEST,
+    IN_PROGRESS,
+    SUCCEED,
+    CANCELED
+}

--- a/src/test/java/com/dsadara/aptApp/MainControllerTest.java
+++ b/src/test/java/com/dsadara/aptApp/MainControllerTest.java
@@ -1,5 +1,6 @@
 package com.dsadara.aptApp;
 
+import com.dsadara.aptApp.main.MainController;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
### **요약**
프로젝트의 대략적인 패키지 구조를 구현하고, erd를 참고하여 엔티티를 구현
- erd 주소: https://www.erdcloud.com/d/mhdvDKhPQgq9Kvvbf
### **작업한 것**
1. 도메인별로 패키지를 구성하였습니다.
   - 예: 아파트, 아파트덧글, 관심아파트 엔티티 -> Apartment 패키지
3. 각 테이블에 해당하는 엔티티를 작성했습니다.
4. 각 엔티티에 해당하는 레포지토리를 작성했습니다. 
### **관련 이슈**
* https://github.com/dsadara/aptApp/issues/3
### **질문 사항**
1. 엔티티들이 많기도 하고, 그룹화 시킬 수 있다고 생각하여
도메인별로 패키지를 구성했는데 이렇게 진행해도 무방할까요?
     - 예: apartment \- controller, entity, repository, service
         member \- controller, entity, repository, service 
3. 아파트 엔티티에는 세부사항이 많아서 컬럼 수가 많습니다. 
아파트 세부사항 엔티티를 만들고 일대일 매핑관계를 이용해서 분리하는 것이 좋을까요?
5. 상담(Consult) 엔티티에는 채팅 기록을 Json컬럼으로 저장하고 있는데요. 
아무래도 속도가 느릴 것 같은데 이렇게 진행해도 괜찮을까요? 
아니면 채팅 기록 엔티티를 따로 만드는 것이 괜찮을 까요? 
(사실 소켓을 이용한 채팅을 구현해본 적이 없어서 아직은 감이 안오네요..) 
