### PR TITLE
Apartment 엔티티 API 구현 #6

### DIFF
--- a/src/main/java/com/dsadara/aptApp/apartment/controller/ApartmentController.java
+++ b/src/main/java/com/dsadara/aptApp/apartment/controller/ApartmentController.java
@@ -1,0 +1,88 @@
+package com.dsadara.aptApp.apartment.controller;
+
+import com.dsadara.aptApp.apartment.dto.ApartmentInfo;
+import com.dsadara.aptApp.apartment.dto.ApartmentInfoSimple;
+import com.dsadara.aptApp.apartment.dto.CreateApartment;
+import com.dsadara.aptApp.apartment.service.ApartmentService;
+import com.dsadara.aptApp.apartment.type.ApartmentFeature;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequiredArgsConstructor
+public class ApartmentController {
+    private final ApartmentService apartmentService;
+
+    // 아파트 저장 API (관리자)
+    @PostMapping("/apt")
+    public CreateApartment.Response createApartment(
+            @RequestBody CreateApartment.Request request
+    ) {
+        return CreateApartment.Response.from(
+                apartmentService.createApartment(request)
+        );
+    }
+
+    // 아파트 검색 API
+    @GetMapping("/apt")
+    public List<ApartmentInfoSimple> getApartment(
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) String as1,
+            @RequestParam(required = false) String as2,
+            @RequestParam(required = false) String as3,
+            @RequestParam(required = false) String as4,
+            @RequestParam(required = false) ApartmentFeature feature
+    ) {
+        if (name != null) {             // - 단지명 검색
+            return apartmentService.getApartmentByName(name).stream()
+                    .map(ApartmentInfoSimple::fromEntity)
+                    .collect(Collectors.toList());
+        } else if (as1 != null) {       //- 시도별 검색
+            return apartmentService.getApartmentByAs1(as1).stream()
+                    .map(ApartmentInfoSimple::fromEntity)
+                    .collect(Collectors.toList());
+        } else if (as2 != null) {       //- 시군구 검색
+            return apartmentService.getApartmentByAs2(as2).stream()
+                    .map(ApartmentInfoSimple::fromEntity)
+                    .collect(Collectors.toList());
+        } else if (as3 != null) {       //- 읍면 검색
+            return apartmentService.getApartmentByAs3(as3).stream()
+                    .map(ApartmentInfoSimple::fromEntity)
+                    .collect(Collectors.toList());
+        } else if (as4 != null) {       //- 동리 검색
+            return apartmentService.getApartmentByAs4(as4).stream()
+                    .map(ApartmentInfoSimple::fromEntity)
+                    .collect(Collectors.toList());
+        } else if (feature != null) {   //- 특징 검색
+            return apartmentService.getApartmentByFeature(feature).stream()
+                    .map(ApartmentInfoSimple::fromEntity)
+                    .collect(Collectors.toList());
+        }
+        return null;
+    }
+
+    //- 아파트 상세 정보 조회 API
+    @GetMapping("/apt/detail")
+    public ApartmentInfo getApartmentDetail(
+            @RequestParam String aptCode
+    ) {
+        return ApartmentInfo.fromEntity(apartmentService.getApartmentDetail(aptCode));
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/main/java/com/dsadara/aptApp/apartment/dto/ApartmentDto.java
+++ b/src/main/java/com/dsadara/aptApp/apartment/dto/ApartmentDto.java
@@ -1,0 +1,35 @@
+package com.dsadara.aptApp.apartment.dto;
+
+import com.dsadara.aptApp.apartment.entity.Apartment;
+import com.dsadara.aptApp.apartment.type.ApartmentFeature;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ApartmentDto {
+    private String aptCode;         // 단지코드
+    private String name;            // 단지명
+    private String as1;             // 시, 도
+    private String as2;             // 시, 군, 구
+    private String as3;             // 읍, 면
+    private String as4;             // 동, 리
+
+    private List<ApartmentFeature> feature;   // 특징
+
+    public static ApartmentDto fromEntity(Apartment apartment) {
+        return ApartmentDto.builder()
+                .aptCode(apartment.getAptCode())
+                .name(apartment.getName())
+                .as1(apartment.getAs1())
+                .as2(apartment.getAs2())
+                .as3(apartment.getAs3())
+                .as4(apartment.getAs4())
+                .feature(apartment.getFeature())
+                .build();
+    }
+}

--- a/src/main/java/com/dsadara/aptApp/apartment/dto/ApartmentInfo.java
+++ b/src/main/java/com/dsadara/aptApp/apartment/dto/ApartmentInfo.java
@@ -1,0 +1,55 @@
+package com.dsadara.aptApp.apartment.dto;
+
+import com.dsadara.aptApp.apartment.entity.Apartment;
+import com.dsadara.aptApp.apartment.type.ApartmentFeature;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ApartmentInfo {
+    // client와 controller간의 정보를 주고 받는 응답 dto
+
+    private String aptCode;         // 단지코드
+    private Long amountRecent;    // 최근 거래금액
+    private Integer viewWeek;     // 주간 조회수
+    private Integer viewTotal;      // 전체 조회수
+    private String name;            // 단지명
+    private String as1;             // 시, 도
+    private String as2;             // 시, 군, 구
+    private String as3;             // 읍, 면
+    private String as4;             // 동, 리
+    private String drmAddress;          // 도로명주소
+    private LocalDate apprvDate;    // 사용승인일
+    private Integer dongNo;             // 동수
+    private Integer houseNo;            // 세대수
+    private Integer parkingSpaceNo;     // 총 주차대수
+    private String bjdCode;             // 법정동코드
+
+    private List<ApartmentFeature> feature;   // 특징
+
+    public static ApartmentInfo fromEntity(Apartment apartment) {
+        return ApartmentInfo.builder()
+                .aptCode(apartment.getAptCode())
+                .amountRecent(apartment.getAmountRecent())
+                .viewWeek(apartment.getViewWeek())
+                .viewTotal(apartment.getViewTotal())
+                .name(apartment.getName())
+                .as1(apartment.getAs1())
+                .as2(apartment.getAs2())
+                .as3(apartment.getAs3())
+                .as4(apartment.getAs4())
+                .drmAddress(apartment.getDrmAddress())
+                .apprvDate(apartment.getApprvDate())
+                .dongNo(apartment.getDongNo())
+                .houseNo(apartment.getHouseNo())
+                .parkingSpaceNo(apartment.getParkingSpaceNo())
+                .bjdCode(apartment.getBjdCode())
+                .build();
+    }
+}

--- a/src/main/java/com/dsadara/aptApp/apartment/dto/ApartmentInfoSimple.java
+++ b/src/main/java/com/dsadara/aptApp/apartment/dto/ApartmentInfoSimple.java
@@ -1,0 +1,36 @@
+package com.dsadara.aptApp.apartment.dto;
+
+import com.dsadara.aptApp.apartment.type.ApartmentFeature;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ApartmentInfoSimple {
+    // client와 controller간의 정보를 주고 받는 응답 dto
+
+    private String aptCode;         // 단지코드
+    private String name;            // 단지명
+    private String as1;             // 시, 도
+    private String as2;             // 시, 군, 구
+    private String as3;             // 읍, 면
+    private String as4;             // 동, 리
+
+    private List<ApartmentFeature> feature;   // 특징
+
+    public static ApartmentInfoSimple fromEntity(ApartmentDto apartmentDto) {
+        return ApartmentInfoSimple.builder()
+                .aptCode(apartmentDto.getAptCode())
+                .name(apartmentDto.getName())
+                .as1(apartmentDto.getAs1())
+                .as2(apartmentDto.getAs2())
+                .as3(apartmentDto.getAs3())
+                .as4(apartmentDto.getAs4())
+                .feature(apartmentDto.getFeature())
+                .build();
+    }
+}

--- a/src/main/java/com/dsadara/aptApp/apartment/dto/CreateApartment.java
+++ b/src/main/java/com/dsadara/aptApp/apartment/dto/CreateApartment.java
@@ -1,0 +1,60 @@
+package com.dsadara.aptApp.apartment.dto;
+
+import com.dsadara.aptApp.apartment.type.ApartmentFeature;
+import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class CreateApartment {
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Request {
+        private String aptCode;         // 단지코드
+        private String name;            // 단지명
+        private String as1;             // 시, 도
+        private String as2;             // 시, 군, 구
+        private String as3;             // 읍, 면
+        private String as4;             // 동, 리
+        private String drmAddress;          // 도로명주소
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        private LocalDate apprvDate;    // 사용승인일
+        private Integer dongNo;             // 동수
+        private Integer houseNo;            // 세대수
+        private Integer parkingSpaceNo;     // 총 주차대수
+        private String bjdCode;             // 법정동코드
+        private List<ApartmentFeature> feature;   // 특징
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        private String aptCode;         // 단지코드
+        private String name;            // 단지명
+        private String as1;             // 시, 도
+        private String as2;             // 시, 군, 구
+        private String as3;             // 읍, 면
+        private String as4;             // 동, 리
+
+        private List<ApartmentFeature> feature;   // 특징
+
+        public static Response from(ApartmentDto apartmentDto) {
+            return Response.builder()
+                    .aptCode(apartmentDto.getAptCode())
+                    .name(apartmentDto.getName())
+                    .as1(apartmentDto.getAs1())
+                    .as2(apartmentDto.getAs2())
+                    .as3(apartmentDto.getAs3())
+                    .as4(apartmentDto.getAs4())
+                    .feature(apartmentDto.getFeature())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/dsadara/aptApp/apartment/entity/Apartment.java
+++ b/src/main/java/com/dsadara/aptApp/apartment/entity/Apartment.java
@@ -1,25 +1,27 @@
 package com.dsadara.aptApp.apartment.entity;
 
+import com.dsadara.aptApp.apartment.type.ApartmentFeature;
 import com.dsadara.aptApp.common.entity.BaseEntity;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import com.vladmihalcea.hibernate.type.json.JsonType;
+import lombok.*;
 import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 @Entity
+@TypeDef(name = "json", typeClass = JsonType.class)
 public class Apartment extends BaseEntity {
     private String aptCode;         // 단지코드
-    private String amountRecent;    // 최근 거래금액
+    private Long amountRecent;    // 최근 거래금액
     private Integer viewWeek;     // 주간 조회수
     private Integer viewTotal;      // 전체 조회수
     private String name;            // 단지명
@@ -28,13 +30,13 @@ public class Apartment extends BaseEntity {
     private String as3;             // 읍, 면
     private String as4;             // 동, 리
     private String drmAddress;          // 도로명주소
-    private LocalDateTime apprvDate;    // 사용승인일
+    private LocalDate apprvDate;    // 사용승인일
     private Integer dongNo;             // 동수
     private Integer houseNo;            // 세대수
     private Integer parkingSpaceNo;     // 총 주차대수
     private String bjdCode;             // 법정동코드
 
-    @Type(type="json")
+    @Type(type = "json")
     @Column(columnDefinition = "json")
-    private List<String> feature;   // 특징
+    private List<ApartmentFeature> feature;   // 특징
 }

--- a/src/main/java/com/dsadara/aptApp/apartment/exception/ApartmentException.java
+++ b/src/main/java/com/dsadara/aptApp/apartment/exception/ApartmentException.java
@@ -1,0 +1,19 @@
+package com.dsadara.aptApp.apartment.exception;
+
+import com.dsadara.aptApp.common.type.ErrorCode;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ApartmentException extends RuntimeException {
+    private ErrorCode errorCode;
+    private String errorMessage;
+
+    public ApartmentException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorCode.getDescription();
+    }
+}

--- a/src/main/java/com/dsadara/aptApp/apartment/repository/ApartmentRepository.java
+++ b/src/main/java/com/dsadara/aptApp/apartment/repository/ApartmentRepository.java
@@ -1,9 +1,33 @@
 package com.dsadara.aptApp.apartment.repository;
 
 import com.dsadara.aptApp.apartment.entity.Apartment;
+import com.dsadara.aptApp.apartment.type.ApartmentFeature;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ApartmentRepository extends JpaRepository<Apartment, Long> {
+    List<Apartment> findByName(String name);
+
+    List<Apartment> findByAs1(String as1);
+
+    List<Apartment> findByAs2(String as2);
+
+    List<Apartment> findByAs3(String as3);
+
+    List<Apartment> findByAs4(String as4);
+
+    @Query(value = "select * from apartment where JSON_CONTAINS(feature, JSON_ARRAY(:#{#paramFeature.name()}))", nativeQuery = true)
+    List<Apartment> findByFeature(@Param("paramFeature") ApartmentFeature apartmentFeature);
+
+    Optional<Apartment> findByAptCode(String aptCode);
+
+    Boolean existsByName(String name);
+
+    Boolean existsByAptCode(String aptCode);
 }

--- a/src/main/java/com/dsadara/aptApp/apartment/service/ApartmentService.java
+++ b/src/main/java/com/dsadara/aptApp/apartment/service/ApartmentService.java
@@ -1,0 +1,115 @@
+package com.dsadara.aptApp.apartment.service;
+
+import com.dsadara.aptApp.apartment.dto.ApartmentDto;
+import com.dsadara.aptApp.apartment.dto.CreateApartment;
+import com.dsadara.aptApp.apartment.entity.Apartment;
+import com.dsadara.aptApp.apartment.exception.ApartmentException;
+import com.dsadara.aptApp.apartment.repository.ApartmentRepository;
+import com.dsadara.aptApp.apartment.type.ApartmentFeature;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.dsadara.aptApp.common.type.ErrorCode.APARTMENT_ALREADY_EXIST;
+import static com.dsadara.aptApp.common.type.ErrorCode.APARTMENT_NOT_FOUND;
+
+
+@RequiredArgsConstructor
+@Service
+public class ApartmentService {
+
+    private final ApartmentRepository apartmentRepository;
+
+    @Transactional
+    public ApartmentDto createApartment(CreateApartment.Request request) {
+        validateCreateApartment(request);
+
+        return ApartmentDto.fromEntity(
+                apartmentRepository.save(
+                        Apartment.builder()
+                                .aptCode(request.getAptCode())
+                                .viewWeek(0)
+                                .viewTotal(0)
+                                .name(request.getName())
+                                .as1(request.getAs1())
+                                .as2(request.getAs2())
+                                .as3(request.getAs3())
+                                .as4(request.getAs4())
+                                .drmAddress(request.getDrmAddress())
+                                .apprvDate(request.getApprvDate())
+                                .dongNo(request.getDongNo())
+                                .houseNo(request.getHouseNo())
+                                .parkingSpaceNo(request.getParkingSpaceNo())
+                                .bjdCode(request.getBjdCode())
+                                .feature(request.getFeature())
+                                .build()
+                )
+        );
+    }
+
+    private void validateCreateApartment(CreateApartment.Request request) {
+        if (apartmentRepository.existsByAptCode(request.getAptCode())) {
+            throw new ApartmentException(APARTMENT_ALREADY_EXIST);
+        }
+        if (apartmentRepository.existsByName(request.getName())) {
+            throw new ApartmentException(APARTMENT_ALREADY_EXIST);
+        }
+    }
+
+    @Transactional
+    public List<ApartmentDto> getApartmentByName(String name) {
+        List<Apartment> apartment = apartmentRepository.findByName(name);
+        return apartment.stream()
+                .map(ApartmentDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public List<ApartmentDto> getApartmentByAs1(String as1) {
+        List<Apartment> apartment = apartmentRepository.findByAs1(as1);
+        return apartment.stream()
+                .map(ApartmentDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public List<ApartmentDto> getApartmentByAs2(String as2) {
+        List<Apartment> apartment = apartmentRepository.findByAs2(as2);
+        return apartment.stream()
+                .map(ApartmentDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public List<ApartmentDto> getApartmentByAs3(String as3) {
+        List<Apartment> apartment = apartmentRepository.findByAs3(as3);
+        return apartment.stream()
+                .map(ApartmentDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public List<ApartmentDto> getApartmentByAs4(String as4) {
+        List<Apartment> apartment = apartmentRepository.findByAs4(as4);
+        return apartment.stream()
+                .map(ApartmentDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public List<ApartmentDto> getApartmentByFeature(ApartmentFeature feature) {
+        List<Apartment> apartment = apartmentRepository.findByFeature(feature);
+        return apartment.stream()
+                .map(ApartmentDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public Apartment getApartmentDetail(String aptCode) {
+        return apartmentRepository.findByAptCode(aptCode)
+                .orElseThrow(() -> new ApartmentException(APARTMENT_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/dsadara/aptApp/apartment/type/ApartmentFeature.java
+++ b/src/main/java/com/dsadara/aptApp/apartment/type/ApartmentFeature.java
@@ -1,0 +1,18 @@
+package com.dsadara.aptApp.apartment.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ApartmentFeature {
+    NEAR_STATION("역세권"),
+    GOOD_SCHOOL("학군지역"),
+    NEAR_RIVER("강변"),
+    NEAR_STREAM("하천"),
+    NEAR_PARK("공원"),
+    NEAR_SUPERMARKET("대형마트"),
+    COUPANG_ROCKET("로켓배송");
+
+    private String krName;
+}

--- a/src/main/java/com/dsadara/aptApp/common/dto/ErrorResponse.java
+++ b/src/main/java/com/dsadara/aptApp/common/dto/ErrorResponse.java
@@ -1,0 +1,14 @@
+package com.dsadara.aptApp.common.dto;
+
+import com.dsadara.aptApp.common.type.ErrorCode;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ErrorResponse {
+    private ErrorCode errorCode;
+    private String errorMessage;
+}

--- a/src/main/java/com/dsadara/aptApp/common/entity/BaseEntity.java
+++ b/src/main/java/com/dsadara/aptApp/common/entity/BaseEntity.java
@@ -8,10 +8,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.EntityListeners;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.MappedSuperclass;
+import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Getter
@@ -22,7 +19,7 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @CreatedDate

--- a/src/main/java/com/dsadara/aptApp/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dsadara/aptApp/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,38 @@
+package com.dsadara.aptApp.common.exception;
+
+import com.dsadara.aptApp.apartment.exception.ApartmentException;
+import com.dsadara.aptApp.common.dto.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import static com.dsadara.aptApp.common.type.ErrorCode.INTERNAL_SERVER_ERROR;
+import static com.dsadara.aptApp.common.type.ErrorCode.INVALID_REQUEST;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ApartmentException.class)
+    public ErrorResponse handleApartmentException(ApartmentException e) {
+        log.error("{} is occuurred.", e.getErrorCode());
+
+        return new ErrorResponse(e.getErrorCode(), e.getErrorMessage());
+    }
+
+    // 아파트를 Enum 타입인 특징(Feature)로 검색할 때 발생 가능한 에러
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ErrorResponse handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.error("MethodArgumentTypeMismatchException is occurred.", e);
+
+        return new ErrorResponse(INVALID_REQUEST, INVALID_REQUEST.getDescription());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ErrorResponse handleException(Exception e) {
+        log.error("Exception is occurred.", e);
+
+        return new ErrorResponse(INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR.getDescription());
+    }
+}

--- a/src/main/java/com/dsadara/aptApp/common/type/ErrorCode.java
+++ b/src/main/java/com/dsadara/aptApp/common/type/ErrorCode.java
@@ -1,0 +1,18 @@
+package com.dsadara.aptApp.common.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    // Apartment
+    APARTMENT_NOT_FOUND("아파트가 없습니다"),
+    APARTMENT_ALREADY_EXIST("이미 아파트가 존재합니다"),
+
+    // Common
+    INVALID_REQUEST("잘못된 요청입니다."),
+    INTERNAL_SERVER_ERROR("내부 서버 오류가 발생했습니다.");
+
+    private String description;
+}

--- a/src/test/java/com/dsadara/aptApp/apartment/service/ApartmentServiceTest.java
+++ b/src/test/java/com/dsadara/aptApp/apartment/service/ApartmentServiceTest.java
@@ -1,0 +1,172 @@
+package com.dsadara.aptApp.apartment.service;
+
+import com.dsadara.aptApp.apartment.dto.ApartmentDto;
+import com.dsadara.aptApp.apartment.dto.CreateApartment;
+import com.dsadara.aptApp.apartment.entity.Apartment;
+import com.dsadara.aptApp.apartment.exception.ApartmentException;
+import com.dsadara.aptApp.common.type.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.dsadara.aptApp.apartment.type.ApartmentFeature.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@Transactional
+public class ApartmentServiceTest {
+    @Autowired
+    private ApartmentService apartmentService;
+
+    @BeforeEach
+    void init() {
+        apartmentService.createApartment(CreateApartment.Request.builder()
+                .aptCode("aptcode1")
+                .name("apt1")
+                .as1("**시").as2("**구").as3("**읍").as4("**동")
+                .drmAddress("도로명주소1")
+                .apprvDate(LocalDate.of(2001, 1, 1))
+                .dongNo(10)
+                .houseNo(1000)
+                .parkingSpaceNo(2000)
+                .bjdCode("bjdcode1")
+                .feature(new ArrayList<>(Arrays.asList(NEAR_STATION, GOOD_SCHOOL)))
+                .build());
+
+        apartmentService.createApartment(CreateApartment.Request.builder()
+                .aptCode("aptcode2")
+                .name("apt2")
+                .as1("##시").as2("**구").as3("##읍").as4("**동")
+                .drmAddress("도로명주소2")
+                .apprvDate(LocalDate.of(2002, 2, 2))
+                .dongNo(20)
+                .houseNo(2000)
+                .parkingSpaceNo(4000)
+                .bjdCode("bjdcode2")
+                .feature(new ArrayList<>(Arrays.asList(NEAR_STATION, NEAR_SUPERMARKET, COUPANG_ROCKET))).build());
+    }
+
+    @Test
+    @DisplayName("아파트 검색 (단지명)")
+    void getApartmentByNameSuccess() {
+        //given
+        //when
+        List<ApartmentDto> apts = apartmentService.getApartmentByName("apt1");
+
+        //then
+        for (ApartmentDto apartmentDto : apts) {
+            assertEquals(apartmentDto.getName(), "apt1");
+        }
+    }
+
+    @Test
+    @DisplayName("아파트 검색 (시, 도)")
+    void getApartmentByAs1Success() {
+        //given
+        //when
+        List<ApartmentDto> apts = apartmentService.getApartmentByAs1("**시");
+
+        //then
+        for (ApartmentDto apartmentDto : apts) {
+            assertEquals(apartmentDto.getAs1(), "**시");
+            assertEquals(apartmentDto.getName(), "apt1");
+        }
+    }
+
+    @Test
+    @DisplayName("아파트 검색 (시, 군, 구)")
+    void getApartmentByAs2Success() {
+        //given
+        //when
+        List<ApartmentDto> apts = apartmentService.getApartmentByAs2("**구");
+
+        //then
+        for (ApartmentDto apartmentDto : apts) {
+            assertEquals(apartmentDto.getAs2(), "**구");
+        }
+    }
+
+    @Test
+    @DisplayName("아파트 검색 (읍, 면)")
+    void getApartmentByAs3Success() {
+        //given
+        //when
+        List<ApartmentDto> apts = apartmentService.getApartmentByAs3("**읍");
+
+        //then
+        for (ApartmentDto apartmentDto : apts) {
+            assertEquals(apartmentDto.getAs3(), "**읍");
+            assertEquals(apartmentDto.getName(), "apt1");
+        }
+    }
+
+    @Test
+    @DisplayName("아파트 검색 (동, 리)")
+    void getApartmentByAs4Success() {
+        //given
+        //when
+        List<ApartmentDto> apts = apartmentService.getApartmentByAs4("**동");
+
+        //then
+        for (ApartmentDto apartmentDto : apts) {
+            assertEquals(apartmentDto.getAs4(), "**동");
+        }
+    }
+
+    @Test
+    @DisplayName("아파트 상세 정보 조회")
+    void getApartmentDetailSuccess() {
+        //given
+        //when
+        Apartment apartment = apartmentService.getApartmentDetail("aptcode1");
+
+        //then
+        assertEquals(apartment.getName(), "apt1");
+        assertEquals(apartment.getDrmAddress(), "도로명주소1");
+    }
+
+    @Test
+    @DisplayName("아파트 상세 정보 조회 실패")
+    void getApartmentDetailFailed_ApartmentNotFound() {
+        //given
+        //when
+        ApartmentException exception = assertThrows(ApartmentException.class,
+                () -> apartmentService.getApartmentDetail("wrongcode"));
+
+        //then
+        assertEquals(ErrorCode.APARTMENT_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("아파트 저장 실패")
+    void createApartmentFailed_ApartmentAlreadyExist() {
+        //given
+        CreateApartment.Request request = CreateApartment.Request.builder()
+                .aptCode("aptcode1")
+                .name("apt1")
+                .as1("**시").as2("**구").as3("**읍").as4("**동")
+                .drmAddress("도로명주소1")
+                .apprvDate(LocalDate.of(2001, 1, 1))
+                .dongNo(10)
+                .houseNo(1000)
+                .parkingSpaceNo(2000)
+                .bjdCode("bjdcode1")
+                .feature(new ArrayList<>(Arrays.asList(NEAR_STATION, GOOD_SCHOOL)))
+                .build();
+        //when
+        ApartmentException exception = assertThrows(ApartmentException.class,
+                () -> apartmentService.createApartment(request));
+
+        //then
+        assertEquals(ErrorCode.APARTMENT_ALREADY_EXIST, exception.getErrorCode());
+    }
+}

--- a/src/test/java/com/dsadara/aptApp/main/MainControllerTest.java
+++ b/src/test/java/com/dsadara/aptApp/main/MainControllerTest.java
@@ -1,6 +1,5 @@
-package com.dsadara.aptApp;
+package com.dsadara.aptApp.main;
 
-import com.dsadara.aptApp.main.MainController;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
### **요약**
Apartment 엔티티 관련 API 구현, 예외 처리, 테스트 코드 작성
### **작업한 것**
1. 아파트 저장 API 구현
2. 아파트 검색 API 구현
   - 단지명, 시도, 시군구, 읍면, 특징별로 검색
   - Json 컬럼인 특징(Feature)을 검색할 때는 Native Query로 구현
3. 아파트 상세 조회 API 구현
4. 전역 예외처리 구현
   - GlobalExceptionHandler
6. 아파트 도메인 예외처리 구현
8. 테스트코드 작성
   - Junit5
### **관련 이슈**
- https://github.com/dsadara/aptApp/issues/6
### **질문 사항**
- ApartmentDto랑 ApartmentInfoSimple하고 동일한데 ApartmentDto 하나로 통일시키는게 좋을까요?
  - ApartmentDto는 Service와 Controller간 정보를 주고받기위해 만들었고,
  ApartmentInfoSimple은 Controller와 Client간 정보를 주고받기 위한 dto입니다.
- NativeQuery를 사용한 API를 테스트시 Junit5으로 잘 안됬었는데 이는 Mock 테스트로 테스트 코드를 작성해야 할까요?
  Junit5로도 테스트가 가능하다면 다시 한번 시도를 해보겠습니다!

